### PR TITLE
Contrast 14968 eclipse plugin never loads more than 20 vulnerabilities

### DIFF
--- a/plugins/com.contrastsecurity.ide.eclipse.core/src/com/contrastsecurity/ide/eclipse/core/Util.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/src/com/contrastsecurity/ide/eclipse/core/Util.java
@@ -15,12 +15,14 @@
 package com.contrastsecurity.ide.eclipse.core;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 
 import com.contrastsecurity.exceptions.UnauthorizedException;
+import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.Organization;
 import com.contrastsecurity.models.Organizations;
 import com.contrastsecurity.sdk.ContrastSDK;
@@ -69,6 +71,24 @@ public class Util {
 			orgArray[i] = orgList.get(i).getName();
 		
 		return orgArray;
+	}
+	
+	public static TraceFilterForm getTraceFilterForm(final int offset, final int limit) {
+		return getTraceFilterForm(null, offset, limit);
+	}
+	
+	public static TraceFilterForm getTraceFilterForm(final Long selectedServerId, final int offset, final int limit) {
+		final TraceFilterForm form = new TraceFilterForm();
+		if(selectedServerId != null) {
+			final List<Long> serverIds = new ArrayList<>();
+			serverIds.add(selectedServerId);
+			form.setServerIds(serverIds);
+		}
+		
+		form.setOffset(offset);
+		form.setLimit(limit);
+		
+		return form;
 	}
 	
 	public static String[] getListFromString(String list) {

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/ContrastUIActivator.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/ContrastUIActivator.java
@@ -14,8 +14,6 @@
  *******************************************************************************/
 package com.contrastsecurity.ide.eclipse.ui;
 
-import java.io.IOException;
-
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -29,9 +27,7 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
-import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.ide.eclipse.core.ContrastCoreActivator;
-import com.contrastsecurity.ide.eclipse.core.Util;
 import com.contrastsecurity.ide.eclipse.ui.cache.ContrastCache;
 import com.contrastsecurity.models.Trace;
 
@@ -133,13 +129,6 @@ public class ContrastUIActivator extends AbstractUIPlugin {
 	}
 	
 	public static String getOrgUuid() {
-		/*String orgUuid = null;
-		try {
-			orgUuid = Util.getDefaultOrganizationUuid();
-		} catch (IOException | UnauthorizedException e) {
-			log(e);
-		}
-		return orgUuid;*/
 		return ContrastCoreActivator.getSelectedOrganizationUuid();
 	}
 	

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/job/RefreshJob.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/job/RefreshJob.java
@@ -36,7 +36,7 @@ public class RefreshJob extends Job {
 		if (monitor.isCanceled()) {
 			return Status.CANCEL_STATUS;
 		}
-		vulnerabilitiesView.refreshTraces();
+		vulnerabilitiesView.refreshTraces(true);
 		if (monitor.isCanceled()) {
 			return Status.CANCEL_STATUS;
 		}

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/ConfigurationPage.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/ConfigurationPage.java
@@ -76,7 +76,7 @@ public class ConfigurationPage extends AbstractPage {
 						getVulnerabilitiesView().getSite().getShell(), ContrastPreferencesPage.ID, null, null);
 				dialog.open();
 				vulnerabilitiesView.refreshSdk();
-				vulnerabilitiesView.refreshTraces();
+				vulnerabilitiesView.refreshTraces(true);
 			}
 
 			@Override

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/IPageLoaderListener.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/IPageLoaderListener.java
@@ -2,8 +2,6 @@ package com.contrastsecurity.ide.eclipse.ui.internal.model;
 
 public interface IPageLoaderListener {
 	
-	void onPreviousPageLoad();
-	void onNextPageLoad();
 	void onPageLoad(int page);
 
 }

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/IPageLoaderListener.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/IPageLoaderListener.java
@@ -1,0 +1,8 @@
+package com.contrastsecurity.ide.eclipse.ui.internal.model;
+
+public interface IPageLoaderListener {
+	
+	void onPreviousPageLoad();
+	void onNextPageLoad();
+
+}

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/IPageLoaderListener.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/IPageLoaderListener.java
@@ -4,5 +4,6 @@ public interface IPageLoaderListener {
 	
 	void onPreviousPageLoad();
 	void onNextPageLoad();
+	void onPageLoad(int page);
 
 }

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/VulnerabilityPage.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/VulnerabilityPage.java
@@ -22,8 +22,11 @@ import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 
@@ -43,13 +46,19 @@ public class VulnerabilityPage extends AbstractPage {
 	private ComboViewer applicationCombo;
 	private Label label;
 	
+	private Button previousBtn;
+	private Button nextBtn;
+	private Label paginationLabel;
+	
+	private IPageLoaderListener pageLoaderListener;
+	
 	public VulnerabilityPage(Composite parent, int style, VulnerabilitiesView vulnerabilitiesView) {
 		super(parent, style, vulnerabilitiesView);
 		setLayout(new GridLayout());
 		GridData gd = new GridData(SWT.FILL, SWT.FILL, true, true);
 		setLayoutData(gd);
 		Composite comboComposite = new Composite(this, SWT.NONE);
-		comboComposite.setLayout(new GridLayout(3, false));
+		comboComposite.setLayout(new GridLayout(6, false));
 		label = new Label(comboComposite, SWT.NONE);
 		gd = new GridData(SWT.FILL, SWT.CENTER, false, false);
 		label.setLayoutData(gd);
@@ -59,6 +68,8 @@ public class VulnerabilityPage extends AbstractPage {
 		updateServerCombo(orgUuid, true);
 		createApplicationCombo(comboComposite, orgUuid);
 		updateApplicationCombo(orgUuid, true);
+		
+		createPaginationUI(comboComposite);
 	}
 	
 	private String getOrgUuid() {
@@ -87,6 +98,41 @@ public class VulnerabilityPage extends AbstractPage {
 		serverCombo.getControl().setFont(composite.getFont());
 		serverCombo.setLabelProvider(new ContrastLabelProvider());
 		serverCombo.setContentProvider(new ArrayContentProvider());
+	}
+	
+	private void createPaginationUI(Composite composite) {
+		GridData gd ;//= new GridData(SWT.FILL, SWT.CENTER, false, false);
+		
+		previousBtn = new Button(composite, SWT.PUSH);
+		previousBtn.setText("Previous");
+		previousBtn.addSelectionListener(new SelectionListener() {
+			
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				pageLoaderListener.onPreviousPageLoad();
+			}
+			
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) { /* Does nothing */ }
+		});
+		
+		paginationLabel = new Label(composite, SWT.NONE);
+		gd = new GridData(SWT.FILL, SWT.CENTER, false, false);
+		paginationLabel.setLayoutData(gd);
+		paginationLabel.setText("1 of 1");
+		
+		nextBtn = new Button(composite, SWT.PUSH);
+		nextBtn.setText("Next");
+		nextBtn.addSelectionListener(new SelectionListener() {
+			
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				pageLoaderListener.onNextPageLoad();
+			}
+			
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) { /* Does nothing */ }
+		});
 	}
 	
 	public void updateServerCombo(final String orgUuid, final boolean setSavedDefaults) {
@@ -162,6 +208,10 @@ public class VulnerabilityPage extends AbstractPage {
 			applicationCombo.setSelection(new StructuredSelection(selected));
 		}
 	}
+	
+	public void setPageLoaderListener(IPageLoaderListener pageLoaderListener) {
+		this.pageLoaderListener = pageLoaderListener;
+	}
 
 	public ComboViewer getServerCombo() {
 		return serverCombo;
@@ -173,6 +223,18 @@ public class VulnerabilityPage extends AbstractPage {
 
 	public Label getLabel() {
 		return label;
+	}
+	
+	public Button getPreviousButton() {
+		return previousBtn;
+	}
+	
+	public Button getNextButton() {
+		return nextBtn;
+	}
+	
+	public void refreshPaginationLabel(int currentPage, int totalPages) {
+		paginationLabel.setText(currentPage + " of " + totalPages);
 	}
 
 }

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/VulnerabilityPage.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/VulnerabilityPage.java
@@ -27,6 +27,7 @@ import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 
@@ -46,9 +47,12 @@ public class VulnerabilityPage extends AbstractPage {
 	private ComboViewer applicationCombo;
 	private Label label;
 	
-	private Button previousBtn;
+	/*private Button previousBtn;
 	private Button nextBtn;
-	private Label paginationLabel;
+	private Label paginationLabel;*/
+	
+	private Label pageLabel;
+	private Combo pageCombo;
 	
 	private IPageLoaderListener pageLoaderListener;
 	
@@ -58,7 +62,7 @@ public class VulnerabilityPage extends AbstractPage {
 		GridData gd = new GridData(SWT.FILL, SWT.FILL, true, true);
 		setLayoutData(gd);
 		Composite comboComposite = new Composite(this, SWT.NONE);
-		comboComposite.setLayout(new GridLayout(6, false));
+		comboComposite.setLayout(new GridLayout(5, false));
 		label = new Label(comboComposite, SWT.NONE);
 		gd = new GridData(SWT.FILL, SWT.CENTER, false, false);
 		label.setLayoutData(gd);
@@ -103,7 +107,7 @@ public class VulnerabilityPage extends AbstractPage {
 	private void createPaginationUI(Composite composite) {
 		GridData gd ;//= new GridData(SWT.FILL, SWT.CENTER, false, false);
 		
-		previousBtn = new Button(composite, SWT.PUSH);
+		/*previousBtn = new Button(composite, SWT.PUSH);
 		previousBtn.setText("Previous");
 		previousBtn.addSelectionListener(new SelectionListener() {
 			
@@ -113,7 +117,7 @@ public class VulnerabilityPage extends AbstractPage {
 			}
 			
 			@Override
-			public void widgetDefaultSelected(SelectionEvent e) { /* Does nothing */ }
+			public void widgetDefaultSelected(SelectionEvent e) { /* Does nothing  }
 		});
 		
 		paginationLabel = new Label(composite, SWT.NONE);
@@ -128,6 +132,23 @@ public class VulnerabilityPage extends AbstractPage {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				pageLoaderListener.onNextPageLoad();
+			}
+			
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) { /* Does nothing  }
+		});*/
+		
+		pageLabel = new Label(composite, SWT.NONE);
+		gd = new GridData(SWT.FILL, SWT.CENTER, false, false);
+		pageLabel.setLayoutData(gd);
+		pageLabel.setText("Page: ");
+		
+		pageCombo = new Combo(composite, SWT.READ_ONLY);
+		pageCombo.addSelectionListener(new SelectionListener() {
+			
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				pageLoaderListener.onPageLoad(Integer.parseInt(pageCombo.getText()));
 			}
 			
 			@Override
@@ -209,7 +230,32 @@ public class VulnerabilityPage extends AbstractPage {
 		}
 	}
 	
-	public void setPageLoaderListener(IPageLoaderListener pageLoaderListener) {
+	public void initializePageCombo(final int pageLimit, final int totalElements) {
+		if(totalElements > pageLimit) {
+			int pages;
+			
+			if(totalElements % pageLimit > 0)
+				pages = totalElements / pageLimit + 1;
+			else
+				pages = totalElements / pageLimit;
+			
+			String[] pagesArray = new String[pages];
+			
+			for(int i = 0; i < pages; i++)
+				pagesArray[i] = String.valueOf(i + 1);
+			
+			pageCombo.setItems(pagesArray);
+			pageCombo.setEnabled(true);
+		}
+		else {
+			pageCombo.setItems(new String[]{"1"});
+			pageCombo.setEnabled(false);
+		}
+		
+		pageCombo.select(0);
+	}
+	
+	public void setPageLoaderListener(final IPageLoaderListener pageLoaderListener) {
 		this.pageLoaderListener = pageLoaderListener;
 	}
 
@@ -225,7 +271,11 @@ public class VulnerabilityPage extends AbstractPage {
 		return label;
 	}
 	
-	public Button getPreviousButton() {
+	public Combo getPageCombo() {
+		return pageCombo;
+	}
+	
+	/*public Button getPreviousButton() {
 		return previousBtn;
 	}
 	
@@ -235,6 +285,6 @@ public class VulnerabilityPage extends AbstractPage {
 	
 	public void refreshPaginationLabel(int currentPage, int totalPages) {
 		paginationLabel.setText(currentPage + " of " + totalPages);
-	}
+	}*/
 
 }

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/VulnerabilityPage.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/VulnerabilityPage.java
@@ -26,7 +26,6 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
@@ -46,10 +45,6 @@ public class VulnerabilityPage extends AbstractPage {
 	private ComboViewer serverCombo;
 	private ComboViewer applicationCombo;
 	private Label label;
-	
-	/*private Button previousBtn;
-	private Button nextBtn;
-	private Label paginationLabel;*/
 	
 	private Label pageLabel;
 	private Combo pageCombo;
@@ -105,38 +100,7 @@ public class VulnerabilityPage extends AbstractPage {
 	}
 	
 	private void createPaginationUI(Composite composite) {
-		GridData gd ;//= new GridData(SWT.FILL, SWT.CENTER, false, false);
-		
-		/*previousBtn = new Button(composite, SWT.PUSH);
-		previousBtn.setText("Previous");
-		previousBtn.addSelectionListener(new SelectionListener() {
-			
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				pageLoaderListener.onPreviousPageLoad();
-			}
-			
-			@Override
-			public void widgetDefaultSelected(SelectionEvent e) { /* Does nothing  }
-		});
-		
-		paginationLabel = new Label(composite, SWT.NONE);
-		gd = new GridData(SWT.FILL, SWT.CENTER, false, false);
-		paginationLabel.setLayoutData(gd);
-		paginationLabel.setText("1 of 1");
-		
-		nextBtn = new Button(composite, SWT.PUSH);
-		nextBtn.setText("Next");
-		nextBtn.addSelectionListener(new SelectionListener() {
-			
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				pageLoaderListener.onNextPageLoad();
-			}
-			
-			@Override
-			public void widgetDefaultSelected(SelectionEvent e) { /* Does nothing  }
-		});*/
+		GridData gd;
 		
 		pageLabel = new Label(composite, SWT.NONE);
 		gd = new GridData(SWT.FILL, SWT.CENTER, false, false);
@@ -270,21 +234,5 @@ public class VulnerabilityPage extends AbstractPage {
 	public Label getLabel() {
 		return label;
 	}
-	
-	public Combo getPageCombo() {
-		return pageCombo;
-	}
-	
-	/*public Button getPreviousButton() {
-		return previousBtn;
-	}
-	
-	public Button getNextButton() {
-		return nextBtn;
-	}
-	
-	public void refreshPaginationLabel(int currentPage, int totalPages) {
-		paginationLabel.setText(currentPage + " of " + totalPages);
-	}*/
 
 }

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/views/VulnerabilitiesView.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/views/VulnerabilitiesView.java
@@ -43,8 +43,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.MouseListener;
-import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -131,20 +129,6 @@ public class VulnerabilitiesView extends ViewPart {
 	};
 	
 	private IPageLoaderListener pageLoaderListener = new IPageLoaderListener() {
-		
-		@Override
-		public void onPreviousPageLoad() {
-			currentOffset -= PAGE_LIMIT;
-			//currentPage.refreshPaginationLabel(currentOffset, total);
-			refreshTraces(false);
-		}
-		
-		@Override
-		public void onNextPageLoad() {
-			currentOffset += PAGE_LIMIT;
-			//currentPage.refreshPaginationLabel(currentOffset, total);
-			refreshTraces(false);
-		}
 		
 		@Override
 		public void onPageLoad(int page) {
@@ -420,7 +404,7 @@ public class VulnerabilitiesView extends ViewPart {
 				});
 				
 				if(isFullRefresh)
-					currentOffset = 0;//TODO Verify if this fixes refresh
+					currentOffset = 0;
 
 				final Traces traces = getTraces(orgUuid, selectedServerId[0], selectedAppId[0], currentOffset, PAGE_LIMIT);
 				if(traces != null)
@@ -498,15 +482,6 @@ public class VulnerabilitiesView extends ViewPart {
 		if (traces != null && traces.getTraces() != null) {
 			Trace[] traceArray = traces.getTraces().toArray(new Trace[0]);
 			viewer.setInput(traceArray);
-			
-			/*if(total <= PAGE_LIMIT)
-				currentPage.getPageCombo().setEnabled(false);
-			else
-				currentPage.getPageCombo().setEnabled(true);*/
-			
-			//Refresh page combo
-			/*if(isFullRefresh)
-				currentPage.initializePageCombo(PAGE_LIMIT, total);*/
 		}
 		if (traces != null && traces.getTraces() != null && traces.getTraces().size() > 0) {
 			if (activePage != mainPage) {
@@ -514,17 +489,6 @@ public class VulnerabilitiesView extends ViewPart {
 				activePage = mainPage;
 				currentPage = mainPage;
 			}
-			
-			/*currentPage.refreshPaginationLabel(Math.floorDiv(currentOffset + traces.getTraces().size(), PAGE_LIMIT), Math.floorDiv(total, PAGE_LIMIT));
-			
-			if(currentOffset + traces.getTraces().size() >= total)
-				currentPage.getNextButton().setEnabled(false);
-			else
-				currentPage.getNextButton().setEnabled(true);
-			if(currentOffset <= 0)
-				currentPage.getPreviousButton().setEnabled(false);
-			else
-				currentPage.getPreviousButton().setEnabled(true);*/
 			
 			currentPage.getServerCombo().setSelection(selectedServer);
 			currentPage.getApplicationCombo().setSelection(selectedApp);
@@ -544,9 +508,6 @@ public class VulnerabilitiesView extends ViewPart {
 			
 			refreshAction.setEnabled(true);
 			addListeners(noVulnerabilitiesPage);
-			
-			/*if(isFullRefresh)
-				currentPage.initializePageCombo(PAGE_LIMIT, total);*/
 		}
 		
 		//Refresh page combo

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/views/VulnerabilitiesView.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/views/VulnerabilitiesView.java
@@ -17,8 +17,6 @@ package com.contrastsecurity.ide.eclipse.ui.internal.views;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
@@ -477,6 +475,8 @@ public class VulnerabilitiesView extends ViewPart {
 	 * @param traces New traces list.
 	 * @param selectedServer Combo selection for server list.
 	 * @param selectedApp Combo selection for application list.
+	 * @param isFullRefresh Indicates if this is just a page change or a UI refresh triggered by filters
+	 * or Refresh button which might change which views are initialized again.
 	 */
 	private void refreshUI(Traces traces, ISelection selectedServer, ISelection selectedApp, final boolean isFullRefresh) {
 		if (traces != null && traces.getTraces() != null) {
@@ -548,37 +548,19 @@ public class VulnerabilitiesView extends ViewPart {
 		}
 		Traces traces = null;
 		if (serverId == Constants.ALL_SERVERS && Constants.ALL_APPLICATIONS.equals(appId)) {
-			TraceFilterForm form = getTraceFilterForm(offset, limit);
+			TraceFilterForm form = Util.getTraceFilterForm(offset, limit);
 			traces = sdk.getTracesInOrg(orgUuid, form);
 		} else if (serverId == Constants.ALL_SERVERS && !Constants.ALL_APPLICATIONS.equals(appId)) {
-			TraceFilterForm form = getTraceFilterForm(offset, limit);
+			TraceFilterForm form = Util.getTraceFilterForm(offset, limit);
 			traces = sdk.getTraces(orgUuid, appId, form);
 		} else if (serverId != Constants.ALL_SERVERS && Constants.ALL_APPLICATIONS.equals(appId)) {
-			TraceFilterForm form = getTraceFilterForm(serverId, offset, limit);
+			TraceFilterForm form = Util.getTraceFilterForm(serverId, offset, limit);
 			traces = sdk.getTracesInOrg(orgUuid, form);
 		} else if (serverId != Constants.ALL_SERVERS && !Constants.ALL_APPLICATIONS.equals(appId)) {
-			TraceFilterForm form = getTraceFilterForm(serverId, offset, limit);
+			TraceFilterForm form = Util.getTraceFilterForm(serverId, offset, limit);
 			traces = sdk.getTraces(orgUuid, appId, form);
 		}
 		return traces;
-	}
-
-	private TraceFilterForm getTraceFilterForm(final int offset, final int limit) {
-		return getTraceFilterForm(null, offset, limit);
-	}
-	
-	private TraceFilterForm getTraceFilterForm(final Long selectedServerId, final int offset, final int limit) {
-		TraceFilterForm form = new TraceFilterForm();
-		if(selectedServerId != null) {
-			List<Long> serverIds = new ArrayList<>();
-			serverIds.add(selectedServerId);
-			form.setServerIds(serverIds);
-		}
-		
-		form.setOffset(offset);
-		form.setLimit(limit);
-		
-		return form;
 	}
 
 	@Override


### PR DESCRIPTION
Implemented pagination so the user is able to see more than 20 vulnerabilites.

* Implemented combo box next to filters.
* The box its filled with the number of pages available per vulnerability search.
* When there are no vulnerabilities or the number of them is lower than the page size (currently is 20), the combo box its set to first page and its disabled.
* Whenever the user refreshes UI with Refresh button or changes search filters, the combo box its set back to first page and its contents are changed.