### PR TITLE
Contrast 17842 sorting does not work

### DIFF
--- a/plugins/com.contrastsecurity.ide.eclipse.core/src/com/contrastsecurity/ide/eclipse/core/Constants.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/src/com/contrastsecurity/ide/eclipse/core/Constants.java
@@ -76,5 +76,6 @@ public interface Constants {
 	
 	static final String SORT_BY_SEVERITY = "severity";
 	static final String SORT_DESCENDING = "-";
+	static final String SORT_BY_TITLE = "title";
 	
 }

--- a/plugins/com.contrastsecurity.ide.eclipse.core/src/com/contrastsecurity/ide/eclipse/core/Constants.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/src/com/contrastsecurity/ide/eclipse/core/Constants.java
@@ -74,4 +74,7 @@ public interface Constants {
 	public String SPAN_CLASS_TAINT = "<span class='taint'>";
 	public int MAX_WIDTH = 400;
 	
+	static final String SORT_BY_SEVERITY = "severity";
+	static final String SORT_DESCENDING = "-";
+	
 }

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/views/VulnerabilitiesView.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/views/VulnerabilitiesView.java
@@ -126,6 +126,8 @@ public class VulnerabilitiesView extends ViewPart {
 			startRefreshJob();
 		}
 	};
+	
+	private String traceSort = Constants.SORT_DESCENDING + Constants.SORT_BY_SEVERITY;
 
 	/**
 	 * The constructor.
@@ -227,6 +229,23 @@ public class VulnerabilitiesView extends ViewPart {
 		TableColumn column = new TableColumn(viewer.getTable(), SWT.NONE);
 		column.setWidth(80);
 		column.setText("Severity");
+		
+		column.addSelectionListener(new SelectionListener() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				if (traceSort.startsWith(Constants.SORT_DESCENDING)) {
+					traceSort = Constants.SORT_BY_SEVERITY;
+				} else {
+					traceSort = Constants.SORT_DESCENDING + Constants.SORT_BY_SEVERITY;
+				}
+				refreshTraces();
+			}
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+			}
+			
+		});
 
 		column = new TableColumn(viewer.getTable(), SWT.NONE);
 		column.setWidth(600);
@@ -235,21 +254,7 @@ public class VulnerabilitiesView extends ViewPart {
 		column = new TableColumn(viewer.getTable(), SWT.NONE);
 		column.setWidth(400);
 		column.setText("Actions");
-		
-		column.addSelectionListener(new SelectionListener() {
-
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				System.out.println("widget selected");
-			}
-
-			@Override
-			public void widgetDefaultSelected(SelectionEvent e) {
-				System.out.println("widget default selected");
-			}
-			
-		});
-		
+				
 		viewer.getTable().addMouseListener(new MouseListener() {
 
 			@Override
@@ -537,24 +542,33 @@ public class VulnerabilitiesView extends ViewPart {
 		}
 		Traces traces = null;
 		if (serverId == Constants.ALL_SERVERS && Constants.ALL_APPLICATIONS.equals(appId)) {
-			traces = sdk.getTracesInOrg(orgUuid, null);
+			TraceFilterForm form = getServerTraceForm(traceSort);
+			traces = sdk.getTracesInOrg(orgUuid, form);
 		} else if (serverId == Constants.ALL_SERVERS && !Constants.ALL_APPLICATIONS.equals(appId)) {
-			traces = sdk.getTraces(orgUuid, appId, null);
+			TraceFilterForm form = getServerTraceForm(traceSort);
+			traces = sdk.getTraces(orgUuid, appId, form);
 		} else if (serverId != Constants.ALL_SERVERS && Constants.ALL_APPLICATIONS.equals(appId)) {
-			TraceFilterForm form = getServerTraceForm(serverId);
+			TraceFilterForm form = getServerTraceForm(serverId, traceSort);
 			traces = sdk.getTracesInOrg(orgUuid, form);
 		} else if (serverId != Constants.ALL_SERVERS && !Constants.ALL_APPLICATIONS.equals(appId)) {
-			TraceFilterForm form = getServerTraceForm(serverId);
+			TraceFilterForm form = getServerTraceForm(serverId, traceSort);
 			traces = sdk.getTraces(orgUuid, appId, form);
 		}
 		return traces;
 	}
 
-	private TraceFilterForm getServerTraceForm(Long selectedServerId) {
+	private TraceFilterForm getServerTraceForm(Long selectedServerId, String sort) {
 		TraceFilterForm form = new TraceFilterForm();
 		List<Long> serverIds = new ArrayList<>();
 		serverIds.add(selectedServerId);
 		form.setServerIds(serverIds);
+		form.setSort(sort);
+		return form;
+	}
+	
+	private TraceFilterForm getServerTraceForm(String sort) {
+		TraceFilterForm form = new TraceFilterForm();
+		form.setSort(sort);
 		return form;
 	}
 

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/views/VulnerabilitiesView.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/views/VulnerabilitiesView.java
@@ -43,12 +43,16 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.MouseListener;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.ui.IActionBars;
@@ -231,6 +235,21 @@ public class VulnerabilitiesView extends ViewPart {
 		column = new TableColumn(viewer.getTable(), SWT.NONE);
 		column.setWidth(400);
 		column.setText("Actions");
+		
+		column.addSelectionListener(new SelectionListener() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				System.out.println("widget selected");
+			}
+
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+				System.out.println("widget default selected");
+			}
+			
+		});
+		
 		viewer.getTable().addMouseListener(new MouseListener() {
 
 			@Override

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/views/VulnerabilitiesView.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/views/VulnerabilitiesView.java
@@ -250,6 +250,23 @@ public class VulnerabilitiesView extends ViewPart {
 		column = new TableColumn(viewer.getTable(), SWT.NONE);
 		column.setWidth(600);
 		column.setText("Vulnerability");
+		
+		column.addSelectionListener(new SelectionListener() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				if (traceSort.startsWith(Constants.SORT_DESCENDING)) {
+					traceSort = Constants.SORT_BY_TITLE;
+				} else {
+					traceSort = Constants.SORT_DESCENDING + Constants.SORT_BY_TITLE;
+				}
+				refreshTraces();
+			}
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+			}
+			
+		});
 
 		column = new TableColumn(viewer.getTable(), SWT.NONE);
 		column.setWidth(400);


### PR DESCRIPTION
Added sorting by vulnerability severity. 
Now it is possible to click on "Severity" table column header to apply the sorting. 
By default all the vulnerabilities are sorted by severity in descending order.