### PR TITLE
CONTRAST-20335

### DIFF
--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/VulnerabilityPage.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/VulnerabilityPage.java
@@ -38,6 +38,7 @@ import com.contrastsecurity.ide.eclipse.core.Constants;
 import com.contrastsecurity.ide.eclipse.core.ContrastCoreActivator;
 import com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator;
 import com.contrastsecurity.ide.eclipse.ui.internal.views.VulnerabilitiesView;
+import com.contrastsecurity.ide.eclipse.ui.util.SystemUtils;
 import com.contrastsecurity.ide.eclipse.ui.util.UIElementUtils;
 import com.contrastsecurity.models.Applications;
 import com.contrastsecurity.models.Server;
@@ -111,30 +112,20 @@ public class VulnerabilityPage extends AbstractPage {
 		rowLayout.marginLeft = 20;
 		severityComposite.setLayout(rowLayout);
 
-		severityLevelNoteButton = createButton(severityComposite, "Note", SWT.TOGGLE);
+		severityLevelNoteButton = createSeverityButton(severityComposite, "Note", SWT.TOGGLE, severityButtonListener, SWT.Selection);
 		severityLevelNoteButton.setSelection(prefs.getBoolean(Constants.SEVERITY_LEVEL_NOTE, false));
-		severityLevelNoteButton.addListener(SWT.Selection, severityButtonListener);
-		severityLevelNoteButton.setLayoutData(new RowData(60, 25));
 
-		severityLevelLowButton = createButton(severityComposite, "Low", SWT.TOGGLE);
+		severityLevelLowButton = createSeverityButton(severityComposite, "Low", SWT.TOGGLE, severityButtonListener, SWT.Selection);
 		severityLevelLowButton.setSelection(prefs.getBoolean(Constants.SEVERITY_LEVEL_LOW, false));
-		severityLevelLowButton.addListener(SWT.Selection, severityButtonListener);
-		severityLevelLowButton.setLayoutData(new RowData(60, 25));
 
-		severityLevelMediumButton = createButton(severityComposite, "Medium", SWT.TOGGLE);
+		severityLevelMediumButton = createSeverityButton(severityComposite, "Medium", SWT.TOGGLE, severityButtonListener, SWT.Selection);
 		severityLevelMediumButton.setSelection(prefs.getBoolean(Constants.SEVERITY_LEVEL_MEDIUM, false));
-		severityLevelMediumButton.addListener(SWT.Selection, severityButtonListener);
-		severityLevelMediumButton.setLayoutData(new RowData(60, 25));
 
-		severityLevelHighButton = createButton(severityComposite, "High", SWT.TOGGLE);
+		severityLevelHighButton = createSeverityButton(severityComposite, "High", SWT.TOGGLE, severityButtonListener, SWT.Selection);
 		severityLevelHighButton.setSelection(prefs.getBoolean(Constants.SEVERITY_LEVEL_HIGH, false));
-		severityLevelHighButton.addListener(SWT.Selection, severityButtonListener);
-		severityLevelHighButton.setLayoutData(new RowData(60, 25));
 
-		severityLevelCriticalButton = createButton(severityComposite, "Critical", SWT.TOGGLE);
+		severityLevelCriticalButton = createSeverityButton(severityComposite, "Critical", SWT.TOGGLE, severityButtonListener, SWT.Selection);
 		severityLevelCriticalButton.setSelection(prefs.getBoolean(Constants.SEVERITY_LEVEL_CRITICAL, false));
-		severityLevelCriticalButton.addListener(SWT.Selection, severityButtonListener);
-		severityLevelCriticalButton.setLayoutData(new RowData(60, 25));
 	}
 
 	private EnumSet<RuleSeverity> getSelectedSeverities() {
@@ -166,9 +157,15 @@ public class VulnerabilityPage extends AbstractPage {
 		prefs.putBoolean(Constants.SEVERITY_LEVEL_HIGH, severityLevelHighButton.getSelection());
 	}
 
-	private Button createButton(Composite composite, String text, int style) {
+	private Button createSeverityButton(Composite composite, String text, int style, Listener listener, int listenerType) {
 		Button button = new Button(composite, style);
 		button.setText(text);
+		button.addListener(listenerType, listener);
+		if(SystemUtils.isMacOS())
+			button.setLayoutData(new RowData(90, 25));
+		else
+			button.setLayoutData(new RowData(60, 25));
+		
 		return button;
 	}
 


### PR DESCRIPTION
* Added fix for severity filters display. The buttons should now display
its text correctly on OSX systems.

![imagen](https://user-images.githubusercontent.com/21998636/35352300-2be7e1f8-0109-11e8-82a0-0eba31c217cb.png)