### PR TITLE
CONTRAST-20249

### DIFF
--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/preferences/ContrastPreferencesPage.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/preferences/ContrastPreferencesPage.java
@@ -375,14 +375,12 @@ public class ContrastPreferencesPage extends PreferencePage implements IWorkbenc
 							} else {
 								testConnectionLabel.setText("Connection confirmed!");
 							}
-						} catch (IOException | UnauthorizedException e1) {
-							ContrastUIActivator.log(e1);
-							MessageDialog.openError(getShell(), "Error from server", e1.getMessage());
-							testConnectionLabel.setText("Connection failed!");
+						} catch (IOException e1) {
+							showErrorMessage(e1, getShell(), "Connection error", "Verify your Contrast URL. If error persists, report this to your Contrast admin.");
+						} catch (UnauthorizedException e1) {
+							showErrorMessage(e1, getShell(), "Access denied", "Verify your credentials and make sure you have access to the selected organization.");
 						} catch (Exception e1) {
-							ContrastUIActivator.log(e1);
-							MessageDialog.openError(getShell(), "Exception", "Unknown exception. Check Team Server URL.");
-							testConnectionLabel.setText("Connection failed!");
+							showErrorMessage(e1, getShell(), "Unknown error", "Unknown exception. Please inform an admin about this.");
 						}
 						finally {
 							composite.layout(true, true);
@@ -401,6 +399,25 @@ public class ContrastPreferencesPage extends PreferencePage implements IWorkbenc
 		} catch (InvocationTargetException | InterruptedException e1) {
 			ContrastUIActivator.log(e1);
 		}
+	}
+	
+	private void showErrorMessage(final Exception e, final Shell shell, final String title, final String message) {
+		ContrastUIActivator.log(e);
+		testConnectionLabel.setText("Connection failed!");
+		
+		new Thread(new Runnable() {
+			public void run() {
+				try {
+					Thread.sleep(100);
+				}
+				catch(InterruptedException e) {
+					//Do nothing
+				}
+				finally {
+					UIElementUtils.ShowErrorMessageFromAnotherThread(Display.getDefault(), shell, title, message);
+				}
+			}
+		}).start();
 	}
 	
 	//===================== Organization combo listeners ========================

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/preferences/ContrastPreferencesPage.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/preferences/ContrastPreferencesPage.java
@@ -376,7 +376,7 @@ public class ContrastPreferencesPage extends PreferencePage implements IWorkbenc
 								testConnectionLabel.setText("Connection confirmed!");
 							}
 						} catch (IOException e1) {
-							showErrorMessage(e1, getShell(), "Connection error", "Verify your Contrast URL. If error persists, report this to your Contrast admin.");
+							showErrorMessage(e1, getShell(), "Connection error", "Could not connect to Contrast. Please verify that the URL is correct and try again.");
 						} catch (UnauthorizedException e1) {
 							showErrorMessage(e1, getShell(), "Access denied", "Verify your credentials and make sure you have access to the selected organization.");
 						} catch (Exception e1) {

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/util/UIElementUtils.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/util/UIElementUtils.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package com.contrastsecurity.ide.eclipse.ui.util;
 
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.jface.viewers.LabelProvider;
@@ -24,6 +25,7 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
@@ -190,6 +192,23 @@ public class UIElementUtils {
 		MessageBox box = new MessageBox(shell, SWT.ICON_ERROR);
 		box.setMessage(message);
 		box.open();
+	}
+	
+	/**
+	 * Shows an error message box with the given parameters. This method should be used when trying to show it from other thread than the UI one. 
+	 * @param display Current SWT display.
+	 * @param shell Parent shell.
+	 * @param title Box title.
+	 * @param message The message to be displayed.
+	 */
+	public static void ShowErrorMessageFromAnotherThread(Display display, Shell shell, String title, String message) {
+		display.asyncExec(new Runnable() {
+			
+			@Override
+			public void run() {
+				MessageDialog.openError(shell, title, message);
+			}
+		});
 	}
 
 }


### PR DESCRIPTION
* Updated error messages for test connection.
* The Error message box should now open after a brief time when testing
connection fails, allowing the progress dialog to close.