### PR TITLE
hide sensitive headers

### DIFF
--- a/plugins/com.contrastsecurity.ide.eclipse.core.tests/src/com/contrastsecurity/ide/eclipse/core/unit/UtilTest.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.core.tests/src/com/contrastsecurity/ide/eclipse/core/unit/UtilTest.java
@@ -1,10 +1,10 @@
 package com.contrastsecurity.ide.eclipse.core.unit;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 import com.contrastsecurity.ide.eclipse.core.Util;
-
-import static org.junit.Assert.assertEquals;
 
 public class UtilTest {
 	
@@ -27,5 +27,24 @@ public class UtilTest {
 			assertEquals(NAME_ARRAY[i], list[i]);
 		}
 	}
+	
+    @Test
+    public void filterHeadersTest() {
+        String authorizationString = "Authorization: Basic Z3Vl...Q6Z3Vlc3Q=";
+        String intuitTidString = "intuit_tid: iasjdfjas9023423234lkj24";
+        String tokenString = "token : afskjfasdfljljasdfljasdf";
+
+        String goodString1 = "/plugin_extracted/plugin/DBCrossSiteScripting/jsp/EditProfile.jsp";
+        String goodString2 = "/plugin_extracted/plugin/DBCrossSiteScripting/jsp/DBCrossSiteScripting.jsp";
+        String goodString3 = "/plugin_extracted/plugin/SQLInjection/jsp/ViewProfile.jsp";
+
+        String separator = "\n";
+        String data = goodString1 + separator + authorizationString + separator + goodString2 + separator +
+                intuitTidString + separator + goodString3 + separator + tokenString;
+
+        String filtered = Util.filterHeaders(data, separator);
+        assertEquals(goodString1 + separator + goodString2 + separator + goodString3, filtered);
+
+    }
 
 }

--- a/plugins/com.contrastsecurity.ide.eclipse.core/src/com/contrastsecurity/ide/eclipse/core/Util.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.core/src/com/contrastsecurity/ide/eclipse/core/Util.java
@@ -140,4 +140,31 @@ public class Util {
 
 		return buffer.toString();
 	}
+	
+	public static String filterHeaders(String data, String separator) {
+		String[] lines = data.split(separator);
+
+		ArrayList<String> filtered = new ArrayList<>();
+
+		for (String line : lines) {
+			boolean filteredLine = true;
+
+			if (line.toLowerCase().contains("authorization:")) {
+				filteredLine = false;
+			} else if (line.toLowerCase().contains("intuit_tid:")) {
+				filteredLine = false;
+			} else if (line.toLowerCase().contains(":")) {
+				if (line.split(":")[0].toLowerCase().contains("token")) {
+					filteredLine = false;
+				}
+			}
+
+			if (filteredLine) {
+				filtered.add(line);
+			}
+
+		}
+
+		return String.join(separator, filtered);
+	}
 }

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/HttpRequestTab.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/HttpRequestTab.java
@@ -26,6 +26,7 @@ import org.eclipse.swt.widgets.Display;
 import org.unbescape.html.HtmlEscape;
 
 import com.contrastsecurity.ide.eclipse.core.Constants;
+import com.contrastsecurity.ide.eclipse.core.Util;
 import com.contrastsecurity.ide.eclipse.core.extended.HttpRequestResource;
 import com.contrastsecurity.ide.eclipse.ui.ContrastUIActivator;
 
@@ -61,8 +62,9 @@ public class HttpRequestTab extends Composite {
 		this.httpRequest = httpRequest;
 		area.setText(Constants.BLANK);
 		if (httpRequest != null && httpRequest.getHttpRequest() != null
-				&& httpRequest.getHttpRequest().getFormattedText() != null) {
-			area.setText(httpRequest.getHttpRequest().getText().replace(Constants.MUSTACHE_NL, Constants.BLANK));
+				&& httpRequest.getHttpRequest().getText() != null) {
+			
+			area.setText(Util.filterHeaders(httpRequest.getHttpRequest().getText(), "\n"));
 		} else if (httpRequest != null && httpRequest.getReason() != null) {
 			area.setText(httpRequest.getReason());
 		}

--- a/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/OverviewTab.java
+++ b/plugins/com.contrastsecurity.ide.eclipse.ui/src/com/contrastsecurity/ide/eclipse/ui/internal/model/OverviewTab.java
@@ -30,6 +30,7 @@ import org.eclipse.swt.widgets.Label;
 import org.unbescape.html.HtmlEscape;
 
 import com.contrastsecurity.ide.eclipse.core.Constants;
+import com.contrastsecurity.ide.eclipse.core.Util;
 import com.contrastsecurity.ide.eclipse.core.extended.Chapter;
 import com.contrastsecurity.ide.eclipse.core.extended.PropertyResource;
 import com.contrastsecurity.ide.eclipse.core.extended.Risk;
@@ -106,6 +107,7 @@ public class OverviewTab extends AbstractTab {
 					textArea.setLayoutData(gd);
 					textArea.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_GRAY));
 					areaText = parseMustache(areaText);
+					areaText = Util.filterHeaders(areaText, "\n");
 					textArea.setText(areaText);
 					//new Label(control, SWT.NONE);
 				}


### PR DESCRIPTION
Now, lines containing “authorization”, “intuit_tid”, and “token” are not displayed in the overview and http tabs.

For testing, this trace can be used: 1HFC-U9UW-6YK2-TVSN, which is in organization: df460336-41b4-4304-b848-d844009fef5a.

![image](https://user-images.githubusercontent.com/18661283/47946541-a8207d00-ded2-11e8-8981-0ed0b3c4db6d.png)
